### PR TITLE
Use addArray() and addMap() when building CBOR in example app

### DIFF
--- a/example_app/src/main/java/com/google/mdoc/example/GetCredentialActivity.kt
+++ b/example_app/src/main/java/com/google/mdoc/example/GetCredentialActivity.kt
@@ -100,7 +100,7 @@ class GetCredentialActivity : ComponentActivity() {
 
     fun respondWithCredential() {
         val hpke = MdocHpke(mdocOption.publicKey)
-        val handoverBytes = when (mdocOption.handover) {
+        val sessionTranscriptBytes = when (mdocOption.handover) {
             MdocHandover.ANDROID -> hpke.generateAndroidSessionTranscript(
                 nonce = mdocOption.nonce,
                 publicKey = mdocOption.publicKey,
@@ -113,7 +113,7 @@ class GetCredentialActivity : ComponentActivity() {
             )
         }
 
-        val (encryptedData, encapKey) = hpke.encrypt(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE, handoverBytes)
+        val (encryptedData, encapKey) = hpke.encrypt(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE, sessionTranscriptBytes)
         val credential =
             MdocCredential(encryptedData, encapKey)
         val response = GetCredentialResponse(credential)

--- a/example_app/src/main/java/com/google/mdoc/example/MdocHpke.kt
+++ b/example_app/src/main/java/com/google/mdoc/example/MdocHpke.kt
@@ -240,10 +240,10 @@ class MdocHpke(private val publicKey: PublicKey, private val privateKey: Private
         val baos = ByteArrayOutputStream()
         CborEncoder(baos).encode(
             CborBuilder()
-                .startArray() // SessionTranscript
+                .addArray() // SessionTranscript
                 .add(SimpleValue.NULL) // DeviceEngagementBytes
                 .add(SimpleValue.NULL) // EReaderKeyBytes
-                .startArray() // AndroidHandover
+                .addArray() // AndroidHandover
                 .add(ANDROID_HANDOVER_V1)
                 .add(nonce)
                 .add(packageName.toByteArray())
@@ -259,7 +259,7 @@ class MdocHpke(private val publicKey: PublicKey, private val privateKey: Private
         val baos = ByteArrayOutputStream()
         CborEncoder(baos).encode(
             CborBuilder()
-                .startMap()
+                .addMap()
                 .put("cat", 1)
                 .put("type", 1)
                 .putMap("details")
@@ -284,7 +284,7 @@ class MdocHpke(private val publicKey: PublicKey, private val privateKey: Private
     //      "BrowserHandoverv1",
     //      nonce,
     //      OriginInfoBytes, // origin of the request as defined in ISO/IEC 18013-7
-    //      RequesterIdentity,
+    //      RequesterIdentity, // ? (omitting)
     //      pkRHash
     //    ]
     fun generateBrowserSessionTranscript(
@@ -297,10 +297,10 @@ class MdocHpke(private val publicKey: PublicKey, private val privateKey: Private
         val baos = ByteArrayOutputStream()
         CborEncoder(baos).encode(
             CborBuilder()
-                .startArray() // SessionTranscript
+                .addArray() // SessionTranscript
                 .add(SimpleValue.NULL) // DeviceEngagementBytes
                 .add(SimpleValue.NULL) // EReaderKeyBytes
-                .startArray() // BrowserHandover
+                .addArray() // BrowserHandover
                 .add(BROWSER_HANDOVER_V1)
                 .add(nonce)
                 .add(originInfoBytes)


### PR DESCRIPTION
This avoids use of chunked encoding, which is unexpected for things like
the Session Transcript.
