### PR TITLE
Include `portrait` in the example app output

### DIFF
--- a/example_app/src/main/java/com/google/mdoc/example/CborUtils.kt
+++ b/example_app/src/main/java/com/google/mdoc/example/CborUtils.kt
@@ -48,10 +48,10 @@ class CborUtils {
                 val value = decoded[0]["elementValue"]
 
                 if (value.majorType == MajorType.BYTE_STRING) {
-                    continue
+                    result[identifier] = "<bytes>";
+                } else {
+                    result[identifier] = value.toString()
                 }
-
-                result[identifier] = value.toString()
             }
 
             return result


### PR DESCRIPTION
It still doesn't show the image, but showing it in the output lets folks
know it's present.
